### PR TITLE
feat: sendgrid put_html add lf to br

### DIFF
--- a/lib/materia/mails/mail_client_sendgrid.ex
+++ b/lib/materia/mails/mail_client_sendgrid.ex
@@ -21,6 +21,7 @@ defmodule Materia.Mails.MailClientSendGrid do
     |> Email.add_to(to)
     |> Email.put_from(from, from_name)
     |> Email.put_text(body_text)
+    |> Email.put_html(String.replace(body_text, "\n", "<br/>"))
     |> Email.put_subject(subject)
     |> Mailer.send()
 


### PR DESCRIPTION
Textメールを送信しても､HTMLに解釈される場合がある｡
その場合､テンプレートの改行(\n)は<br/>に置換されないため､メールが崩れる